### PR TITLE
Forced white space preserving while working with xml to fix missing spaces in word files.

### DIFF
--- a/include/duckx/duckx.hpp
+++ b/include/duckx/duckx.hpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <stdlib.h>
 #include <string>
+#include <unordered_map>
 
 #include <pugixml.hpp>
 #include <zip.h>
@@ -146,6 +147,8 @@ class Document {
     pugi::xml_document document;
     bool flag_is_open;
 
+    std::unordered_map<std::string, std::string> fileReplaceMap;
+
   public:
     Document();
     Document(std::string);
@@ -156,6 +159,7 @@ class Document {
     void save() const;
     bool is_open() const;
 
+    bool replace_file(std::string const& originalFilePath, std::string const& newFilePath);
     Paragraph &paragraphs();
     Table &tables();
 };

--- a/src/duckx.cpp
+++ b/src/duckx.cpp
@@ -272,7 +272,7 @@ void duckx::Document::open() {
     zip_entry_close(zip);
     zip_close(zip);
 
-    this->document.load_buffer(buf, bufsize);
+    this->document.load_buffer(buf, bufsize, pugi::parse_default | pugi::parse_ws_pcdata_single);
 
     free(buf);
 


### PR DESCRIPTION
Problem:
`<w:t xml:space="preserve"> </w:t>`
is turned into
`<w:t xml:space="preserve"/>`

This removes a whitespace from the location.

Solution:
Added a flag to preserve white space elements while reading the document file.